### PR TITLE
Create a `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+*v*env*


### PR DESCRIPTION
This ignores the following files:
- The macOS-specific `.DS_Store`
- The `venv`, `.venv`, and other Python virtual enviroment directories.
This stops them from accidentally being commited.